### PR TITLE
New endpoint /accounts/{id}/servers to get DOMEServer without IP

### DIFF
--- a/src/main/java/org/dmc/services/DomeServerService.java
+++ b/src/main/java/org/dmc/services/DomeServerService.java
@@ -17,10 +17,23 @@ public class DomeServerService {
 
 	static final Logger LOG = LoggerFactory.getLogger(ServerAccessService.class);
 	
-	//returns all public servers and user's own servers
+	/**
+	 * @param userId
+	 * @param page
+	 * @return All public servers and user's own servers
+	 */
 	public List<DomeServer> findAllServers(Integer userId, Pageable page){
 		LOG.info("Get all accessible servers: (user: {})", userId);
 		return serverRepo.findAllServers(userId, page).getContent();
+	}
+	
+	/**
+	 * @param id
+	 * @return DomeServer URL from provided ID
+	 */
+	public String getServerURLById(Integer id) {
+		LOG.info("Get DomeServer URL by id: (id: {})", id);
+		return serverRepo.getServerURLById(id);
 	}
 	
 }

--- a/src/main/java/org/dmc/services/accounts/AccountsController.java
+++ b/src/main/java/org/dmc/services/accounts/AccountsController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.fasterxml.jackson.annotation.JsonView;
+
 import org.dmc.services.DMCServiceException;
 import org.dmc.services.DomeServerService;
 import org.dmc.services.ServerAccessService;
@@ -25,6 +27,7 @@ import org.dmc.services.member.FollowingMemberDao;
 import org.dmc.services.member.FollowingMember;
 import org.dmc.services.products.FavoriteProduct;
 import org.dmc.services.products.FavoriteProductsDao;
+import org.dmc.services.utils.RestViews;
 
 import javax.xml.ws.http.HTTPException;
 
@@ -38,99 +41,123 @@ import static org.springframework.http.MediaType.*;
 @javax.annotation.Generated(value = "class io.swagger.codegen.languages.SpringMVCServerCodegen", date = "2016-02-22T14:57:06.776Z")
 public class AccountsController {
 
-    private final String logTag = AccountsController.class.getName();
-    private AccountsDao accounts = new AccountsDao();
-    
-    @Autowired
-    DomeServerService serverService;
+	private final String logTag = AccountsController.class.getName();
+	private AccountsDao accounts = new AccountsDao();
 
-    @RequestMapping(value = "/{accountID}", produces = { "application/json" }, method = RequestMethod.GET)
-    public ResponseEntity<UserAccount> accountsAccountIDGet(@PathVariable("accountID") String accountID,
-            @RequestHeader(value = "AJP_eppn", defaultValue = "testUser") String userEPPN) {
-        ServiceLogger.log(logTag, "accountsAccountIDGet, accountID: " + accountID);
+	@Autowired
+	DomeServerService serverService;
 
-        int httpStatusCode = HttpStatus.OK.value();
-        UserAccount userAccount = null;
+	@RequestMapping(value = "/{accountID}", produces = { "application/json" }, method = RequestMethod.GET)
+	public ResponseEntity<UserAccount> accountsAccountIDGet(@PathVariable("accountID") String accountID,
+			@RequestHeader(value = "AJP_eppn", defaultValue = "testUser") String userEPPN) {
+		ServiceLogger.log(logTag, "accountsAccountIDGet, accountID: " + accountID);
 
-        try {
-            userAccount = accounts.getUserAccount(accountID, userEPPN);
-        } catch (HTTPException httpException) {
-            httpStatusCode = httpException.getStatusCode();
-        }
+		int httpStatusCode = HttpStatus.OK.value();
+		UserAccount userAccount = null;
 
-        return new ResponseEntity<UserAccount>(userAccount, HttpStatus.valueOf(httpStatusCode));
-    }
+		try {
+			userAccount = accounts.getUserAccount(accountID, userEPPN);
+		} catch (HTTPException httpException) {
+			httpStatusCode = httpException.getStatusCode();
+		}
 
-    @RequestMapping(value = "/{accountID}", produces = { "application/json" }, method = RequestMethod.PATCH)
-    public ResponseEntity<UserAccount> accountsAccountIDPatch(@PathVariable("accountID") String accountID,
-            @RequestBody UserAccount account,
-            @RequestHeader(value = "AJP_eppn", defaultValue = "testUser") String userEPPN) {
-        ServiceLogger.log(logTag, "accountsAccountIDPatch, accountID: " + accountID + ", account.id: " + account.getId()
-                + ", userEPPN: " + userEPPN);
+		return new ResponseEntity<UserAccount>(userAccount, HttpStatus.valueOf(httpStatusCode));
+	}
 
-        int httpStatusCode = HttpStatus.OK.value();
-        UserAccount userAccount = null;
+	@RequestMapping(value = "/{accountID}", produces = { "application/json" }, method = RequestMethod.PATCH)
+	public ResponseEntity<UserAccount> accountsAccountIDPatch(@PathVariable("accountID") String accountID,
+			@RequestBody UserAccount account,
+			@RequestHeader(value = "AJP_eppn", defaultValue = "testUser") String userEPPN) {
+		ServiceLogger.log(logTag, "accountsAccountIDPatch, accountID: " + accountID + ", account.id: " + account.getId()
+				+ ", userEPPN: " + userEPPN);
 
-        try {
-            userAccount = accounts.patchUserAccount(accountID, account, userEPPN);
-        } catch (HTTPException httpException) {
-            httpStatusCode = httpException.getStatusCode();
-        }
-        return new ResponseEntity<UserAccount>(userAccount, HttpStatus.valueOf(httpStatusCode));
-    }
+		int httpStatusCode = HttpStatus.OK.value();
+		UserAccount userAccount = null;
 
-    @RequestMapping(value = "/{accountID}/account-notification-settings", produces = {
-            "application/json" }, method = RequestMethod.GET)
-    public ResponseEntity<List<AccountNotificationSetting>> accountsAccountIDAccountNotificationSettingsGet(
-            @PathVariable("accountID") String accountID) {
-        // do some magic!
-        return new ResponseEntity<List<AccountNotificationSetting>>(HttpStatus.NOT_IMPLEMENTED);
-    }
+		try {
+			userAccount = accounts.patchUserAccount(accountID, account, userEPPN);
+		} catch (HTTPException httpException) {
+			httpStatusCode = httpException.getStatusCode();
+		}
+		return new ResponseEntity<UserAccount>(userAccount, HttpStatus.valueOf(httpStatusCode));
+	}
 
-    @RequestMapping(value = "/{accountID}/account_servers", produces = {
-            "application/json" }, method = RequestMethod.GET)
-    public ResponseEntity accountsAccountIDAccountServersGet(@PathVariable("accountID") String accountID,
-            @RequestParam(value = "_limit", required = false, defaultValue = "10") Integer limit,
-            @RequestParam(value = "_order", required = false, defaultValue = "ASC") String order,
-            @RequestParam(value = "_sort", required = false, defaultValue = "name") String sort) {
+	@RequestMapping(value = "/{accountID}/account-notification-settings", produces = {
+			"application/json" }, method = RequestMethod.GET)
+	public ResponseEntity<List<AccountNotificationSetting>> accountsAccountIDAccountNotificationSettingsGet(
+			@PathVariable("accountID") String accountID) {
+		// do some magic!
+		return new ResponseEntity<List<AccountNotificationSetting>>(HttpStatus.NOT_IMPLEMENTED);
+	}
 
-        try {
-        	ServiceLogger.log(logTag, "In accountsAccountIDAccountServersGet, accountID = " + accountID);
-        	return new ResponseEntity<List<DomeServer>>(serverService.findAllServers(Integer.valueOf(accountID),
-        			new PageRequest(0, limit, order.equals("DESC")?Direction.DESC:Direction.ASC, sort)), HttpStatus.OK);
-        } catch (DMCServiceException e) {
-            ServiceLogger.logException(logTag, e);
-            return new ResponseEntity<String>(e.getMessage(), e.getHttpStatusCode());
-        }
+	@RequestMapping(value = "/{accountID}/account_servers", produces = {
+			"application/json" }, method = RequestMethod.GET)
+	public ResponseEntity accountsAccountIDAccountServersGet(@PathVariable("accountID") String accountID,
+			@RequestParam(value = "_limit", required = false, defaultValue = "10") Integer limit,
+			@RequestParam(value = "_order", required = false, defaultValue = "ASC") String order,
+			@RequestParam(value = "_sort", required = false, defaultValue = "name") String sort) {
 
-    }
+		try {
+			ServiceLogger.log(logTag, "In accountsAccountIDAccountServersGet, accountID = " + accountID);
+			return new ResponseEntity<List<DomeServer>>(
+					serverService.findAllServers(Integer.valueOf(accountID),
+							new PageRequest(0, limit, order.equals("DESC") ? Direction.DESC : Direction.ASC, sort)),
+					HttpStatus.OK);
+		} catch (DMCServiceException e) {
+			ServiceLogger.logException(logTag, e);
+			return new ResponseEntity<String>(e.getMessage(), e.getHttpStatusCode());
+		}
 
-    @RequestMapping(value = "/{accountID}/favorite_products", produces = {
-            "application/json" }, method = RequestMethod.GET)
-    public ResponseEntity<?> accountsAccountIDFavoriteProductsGet(
-            @PathVariable("accountID") String accountID,
-            @RequestParam(value = "_limit", required = false, defaultValue = "25") Integer limit,
-            @RequestParam(value = "_order", required = false, defaultValue = "DESC") String order,
-            @RequestParam(value = "_start", required = false, defaultValue = "0") Integer start,
-            @RequestParam(value = "_sort", required = false, defaultValue = "id") String sort,
-            @RequestHeader(value = "AJP_eppn", required = true) String userEPPN) {
+	}
+	
+	@JsonView(RestViews.SecureServerView.class)
+	@RequestMapping(value = "/{accountID}/servers", produces = {
+			"application/json" }, method = RequestMethod.GET)
+	public ResponseEntity getAccountServersSecureView(@PathVariable("accountID") String accountID,
+			@RequestParam(value = "_limit", required = false, defaultValue = "10") Integer limit,
+			@RequestParam(value = "_order", required = false, defaultValue = "ASC") String order,
+			@RequestParam(value = "_sort", required = false, defaultValue = "name") String sort) {
 
-        ServiceLogger.log(logTag, "In accountsAccountIDFavoriteProductsGet:  as user " + userEPPN);
-        FavoriteProductsDao favoriteProductsDao = new FavoriteProductsDao();
-        List<Integer> accountIds = new ArrayList<Integer>();
-        accountIds.add(Integer.parseInt(accountID));
-        
-        try {
-            return new ResponseEntity<List<FavoriteProduct>>(favoriteProductsDao.getFavoriteProductForAccounts(accountIds, limit, order, start, sort, userEPPN), HttpStatus.OK);
-        } catch (DMCServiceException e) {
-            ServiceLogger.logException(logTag, e);
-            return new ResponseEntity<String>(e.getMessage(), e.getHttpStatusCode());
-        }
-    }
+		try {
+			ServiceLogger.log(logTag, "In getAccountServersSecureView, accountID = " + accountID);
+			return new ResponseEntity<List<DomeServer>>(
+					serverService.findAllServers(Integer.valueOf(accountID),
+							new PageRequest(0, limit, order.equals("DESC") ? Direction.DESC : Direction.ASC, sort)),
+					HttpStatus.OK);
+		} catch (DMCServiceException e) {
+			ServiceLogger.logException(logTag, e);
+			return new ResponseEntity<String>(e.getMessage(), e.getHttpStatusCode());
+		}
 
-    @RequestMapping(value = "/{accountID}/following_companies", produces = {APPLICATION_JSON_VALUE}, method = RequestMethod.GET)
-	public ResponseEntity<?> accountsAccountIDFollowingCompaniesGet(
-			@PathVariable("accountID") String accountID, 
+	}
+
+	@RequestMapping(value = "/{accountID}/favorite_products", produces = {
+			"application/json" }, method = RequestMethod.GET)
+	public ResponseEntity<?> accountsAccountIDFavoriteProductsGet(@PathVariable("accountID") String accountID,
+			@RequestParam(value = "_limit", required = false, defaultValue = "25") Integer limit,
+			@RequestParam(value = "_order", required = false, defaultValue = "DESC") String order,
+			@RequestParam(value = "_start", required = false, defaultValue = "0") Integer start,
+			@RequestParam(value = "_sort", required = false, defaultValue = "id") String sort,
+			@RequestHeader(value = "AJP_eppn", required = true) String userEPPN) {
+
+		ServiceLogger.log(logTag, "In accountsAccountIDFavoriteProductsGet:  as user " + userEPPN);
+		FavoriteProductsDao favoriteProductsDao = new FavoriteProductsDao();
+		List<Integer> accountIds = new ArrayList<Integer>();
+		accountIds.add(Integer.parseInt(accountID));
+
+		try {
+			return new ResponseEntity<List<FavoriteProduct>>(
+					favoriteProductsDao.getFavoriteProductForAccounts(accountIds, limit, order, start, sort, userEPPN),
+					HttpStatus.OK);
+		} catch (DMCServiceException e) {
+			ServiceLogger.logException(logTag, e);
+			return new ResponseEntity<String>(e.getMessage(), e.getHttpStatusCode());
+		}
+	}
+
+	@RequestMapping(value = "/{accountID}/following_companies", produces = {
+			APPLICATION_JSON_VALUE }, method = RequestMethod.GET)
+	public ResponseEntity<?> accountsAccountIDFollowingCompaniesGet(@PathVariable("accountID") String accountID,
 			@RequestParam(value = "limit", required = false) Integer limit,
 			@RequestParam(value = "order", required = false) String order,
 			@RequestParam(value = "sort", required = false) String sort,
@@ -146,37 +173,38 @@ public class AccountsController {
 		}
 	}
 
-    @RequestMapping(value = "/{accountID}/follow_discussions", produces = {
-            APPLICATION_JSON_VALUE }, method = RequestMethod.GET)
-    public ResponseEntity getFollowDiscussionsFromAccountId(
-            @RequestHeader(value = "AJP_eppn", defaultValue = "testUser") String userEPPN,
-            @PathVariable("accountID") String accountID,
-            @RequestParam(value = "individual-discussionId", required = false) String individualDiscussionId,
-            @RequestParam(value = "limit", required = false) Integer limit,
-            @RequestParam(value = "order", required = false) String order,
-            @RequestParam(value = "sort", required = false) String sort) {
-        final FollowDiscussionsDao followDiscussionsDao = new FollowDiscussionsDao();
-        try {
-            ServiceLogger.log(logTag, "In getFollowDiscussionsFromAccountId");
-            return new ResponseEntity<List<FollowingIndividualDiscussion>>(followDiscussionsDao
-                    .getFollowedDiscussionsforAccount(accountID, individualDiscussionId, limit, order, sort, userEPPN),
-                    HttpStatus.OK);
-        } catch (DMCServiceException e) {
-            ServiceLogger.logException(logTag, e);
-            return new ResponseEntity<String>(e.getMessage(), e.getHttpStatusCode());
-        }
-    }
+	@RequestMapping(value = "/{accountID}/follow_discussions", produces = {
+			APPLICATION_JSON_VALUE }, method = RequestMethod.GET)
+	public ResponseEntity getFollowDiscussionsFromAccountId(
+			@RequestHeader(value = "AJP_eppn", defaultValue = "testUser") String userEPPN,
+			@PathVariable("accountID") String accountID,
+			@RequestParam(value = "individual-discussionId", required = false) String individualDiscussionId,
+			@RequestParam(value = "limit", required = false) Integer limit,
+			@RequestParam(value = "order", required = false) String order,
+			@RequestParam(value = "sort", required = false) String sort) {
+		final FollowDiscussionsDao followDiscussionsDao = new FollowDiscussionsDao();
+		try {
+			ServiceLogger.log(logTag, "In getFollowDiscussionsFromAccountId");
+			return new ResponseEntity<List<FollowingIndividualDiscussion>>(followDiscussionsDao
+					.getFollowedDiscussionsforAccount(accountID, individualDiscussionId, limit, order, sort, userEPPN),
+					HttpStatus.OK);
+		} catch (DMCServiceException e) {
+			ServiceLogger.logException(logTag, e);
+			return new ResponseEntity<String>(e.getMessage(), e.getHttpStatusCode());
+		}
+	}
 
-    @RequestMapping(value = "/{accountId}/following_members", produces = { APPLICATION_JSON_VALUE }, method = RequestMethod.GET)
-    public ResponseEntity<List<FollowingMember>> accountsAccountIdFollowingMembersGet(
-            @PathVariable("accountId") String accountId, 
-            @RequestParam(value = "limit", required = false) Integer limit,
-            @RequestParam(value = "start", required = false) Integer start,
-            @RequestParam(value = "order", required = false) String order,
-            @RequestParam(value = "sort", required = false) String sort,
-            @RequestHeader(value = "AJP_eppn", defaultValue = "testUser") String userEPPN) {
-        final FollowingMemberDao dao = new FollowingMemberDao();
-        return new ResponseEntity<List<FollowingMember>>(dao.followingMembersGet(accountId, null, null, limit, start, order, sort, userEPPN), HttpStatus.OK);
-    }
+	@RequestMapping(value = "/{accountId}/following_members", produces = {
+			APPLICATION_JSON_VALUE }, method = RequestMethod.GET)
+	public ResponseEntity<List<FollowingMember>> accountsAccountIdFollowingMembersGet(
+			@PathVariable("accountId") String accountId, @RequestParam(value = "limit", required = false) Integer limit,
+			@RequestParam(value = "start", required = false) Integer start,
+			@RequestParam(value = "order", required = false) String order,
+			@RequestParam(value = "sort", required = false) String sort,
+			@RequestHeader(value = "AJP_eppn", defaultValue = "testUser") String userEPPN) {
+		final FollowingMemberDao dao = new FollowingMemberDao();
+		return new ResponseEntity<List<FollowingMember>>(
+				dao.followingMembersGet(accountId, null, null, limit, start, order, sort, userEPPN), HttpStatus.OK);
+	}
 
 }

--- a/src/main/java/org/dmc/services/company/Company.java
+++ b/src/main/java/org/dmc/services/company/Company.java
@@ -15,9 +15,9 @@ public class Company {
 
 	@JsonView(RestViews.CompaniesShortView.class)
 	private String id;
-  @JsonView(RestViews.CompaniesShortView.class)
+	@JsonView(RestViews.CompaniesShortView.class)
 	private String accountId;
-  @JsonView(RestViews.CompaniesShortView.class)
+	@JsonView(RestViews.CompaniesShortView.class)
 	private String name;
 	private String location;
 	private String description;

--- a/src/main/java/org/dmc/services/company/Company.java
+++ b/src/main/java/org/dmc/services/company/Company.java
@@ -1,19 +1,23 @@
 package org.dmc.services.company;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
 
 import java.util.Objects;
 import org.dmc.services.sharedattributes.FeatureImage;
+import org.dmc.services.utils.RestViews;
 
 @javax.annotation.Generated(value = "class io.swagger.codegen.languages.SpringMVCServerCodegen", date = "2016-05-03T15:13:20.207Z")
 
 public class Company {
 
     private final String logTag = Company.class.getName();
-    
-	
+
+	@JsonView(RestViews.CompaniesShortView.class)
 	private String id;
+  @JsonView(RestViews.CompaniesShortView.class)
 	private String accountId;
+  @JsonView(RestViews.CompaniesShortView.class)
 	private String name;
 	private String location;
 	private String description;
@@ -48,8 +52,8 @@ public class Company {
 	private int favoritesCount;
 	private boolean isOwner;
 	private String owner;
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("id")
@@ -59,8 +63,8 @@ public class Company {
 	public void setId(String id) {
 		this.id = id;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("accountId")
@@ -70,8 +74,8 @@ public class Company {
 	public void setAccountId(String accountId) {
 		this.accountId = accountId;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("name")
@@ -81,8 +85,8 @@ public class Company {
 	public void setName(String name) {
 		this.name = name;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("location")
@@ -92,8 +96,8 @@ public class Company {
 	public void setLocation(String location) {
 		this.location = location;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("description")
@@ -103,8 +107,8 @@ public class Company {
 	public void setDescription(String description) {
 		this.description = description;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("division")
@@ -114,8 +118,8 @@ public class Company {
 	public void setDivision(String division) {
 		this.division = division;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("industry")
@@ -125,8 +129,8 @@ public class Company {
 	public void setIndustry(String industry) {
 		this.industry = industry;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("NAICSCode")
@@ -136,8 +140,8 @@ public class Company {
 	public void setNAICSCode(String nAICSCode) {
 		this.nAICSCode = nAICSCode;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("RDFocus")
@@ -147,8 +151,8 @@ public class Company {
 	public void setRDFocus(String rDFocus) {
 		this.rDFocus = rDFocus;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("customers")
@@ -158,8 +162,8 @@ public class Company {
 	public void setCustomers(String customers) {
 		this.customers = customers;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("awardsReceived")
@@ -169,8 +173,8 @@ public class Company {
 	public void setAwardsReceived(String awardsReceived) {
 		this.awardsReceived = awardsReceived;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("technicalExpertise")
@@ -180,8 +184,8 @@ public class Company {
 	public void setTechnicalExpertise(String technicalExpertise) {
 		this.technicalExpertise = technicalExpertise;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("toolsSoftwareEquipmentMachines")
@@ -191,8 +195,8 @@ public class Company {
 	public void setToolsSoftwareEquipmentMachines(String toolsSoftwareEquipmentMachines) {
 		this.toolsSoftwareEquipmentMachines = toolsSoftwareEquipmentMachines;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("pastCollaborations")
@@ -202,8 +206,8 @@ public class Company {
 	public void setPastCollaborations(String pastCollaborations) {
 		this.pastCollaborations = pastCollaborations;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("collaborationInterests")
@@ -213,8 +217,8 @@ public class Company {
 	public void setCollaborationInterests(String collaborationInterests) {
 		this.collaborationInterests = collaborationInterests;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("pastProjects")
@@ -224,8 +228,8 @@ public class Company {
 	public void setPastProjects(String pastProjects) {
 		this.pastProjects = pastProjects;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("upcomingProjectInterests")
@@ -235,8 +239,8 @@ public class Company {
 	public void setUpcomingProjectInterests(String upcomingProjectInterests) {
 		this.upcomingProjectInterests = upcomingProjectInterests;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("address")
@@ -246,8 +250,8 @@ public class Company {
 	public void setAddress(String address) {
 		this.address = address;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("city")
@@ -257,8 +261,8 @@ public class Company {
 	public void setCity(String city) {
 		this.city = city;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("state")
@@ -268,8 +272,8 @@ public class Company {
 	public void setState(int state) {
 		this.state = state;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("zipCode")
@@ -279,8 +283,8 @@ public class Company {
 	public void setZipCode(String zipCode) {
 		this.zipCode = zipCode;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("twitter")
@@ -290,8 +294,8 @@ public class Company {
 	public void setTwitter(String twitter) {
 		this.twitter = twitter;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("linkedIn")
@@ -301,8 +305,8 @@ public class Company {
 	public void setLinkedIn(String linkedIn) {
 		this.linkedIn = linkedIn;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("website")
@@ -312,8 +316,8 @@ public class Company {
 	public void setWebsite(String website) {
 		this.website = website;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("methodCommunication")
@@ -323,8 +327,8 @@ public class Company {
 	public void setMethodCommunication(String methodCommunication) {
 		this.methodCommunication = methodCommunication;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("email")
@@ -334,8 +338,8 @@ public class Company {
 	public void setEmail(String email) {
 		this.email = email;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("phone")
@@ -345,8 +349,8 @@ public class Company {
 	public void setPhone(String phone) {
 		this.phone = phone;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("categoryTier")
@@ -356,8 +360,8 @@ public class Company {
 	public void setCategoryTier(int categoryTier) {
 		this.categoryTier = categoryTier;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("dateJoined")
@@ -367,8 +371,8 @@ public class Company {
 	public void setDateJoined(String dateJoined) {
 		this.dateJoined = dateJoined;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("reasonJoining")
@@ -378,8 +382,8 @@ public class Company {
 	public void setReasonJoining(String reasonJoining) {
 		this.reasonJoining = reasonJoining;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("featureImage")
@@ -389,8 +393,8 @@ public class Company {
 	public void setFeatureImage(FeatureImage featureImage) {
 		this.featureImage = featureImage;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("logoImage")
@@ -400,8 +404,8 @@ public class Company {
 	public void setLogoImage(String logoImage) {
 		this.logoImage = logoImage;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("follow")
@@ -411,8 +415,8 @@ public class Company {
 	public void setFollow(boolean follow) {
 		this.follow = follow;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("favoritesCount")
@@ -422,8 +426,8 @@ public class Company {
 	public void setFavoritesCount(int favoritesCount) {
 		this.favoritesCount = favoritesCount;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("isOwner")
@@ -433,8 +437,8 @@ public class Company {
 	public void setIsOwner(boolean isOwner) {
 		this.isOwner = isOwner;
 	}
-	
-	
+
+
 	/**
 	 **/
 	@JsonProperty("owner")
@@ -444,9 +448,9 @@ public class Company {
 	public void setOwner(String owner) {
 		this.owner = owner;
 	}
-	
-	
-	
+
+
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -493,17 +497,17 @@ public class Company {
         Objects.equals(isOwner, company.isOwner) &&
         Objects.equals(owner, company.owner);
 	}
-	
+
 	@Override
 	public int hashCode() {
 		return Objects.hash(id, accountId, name, location, description, division, industry, nAICSCode, rDFocus, customers, awardsReceived, technicalExpertise, toolsSoftwareEquipmentMachines, pastCollaborations, collaborationInterests, pastProjects, upcomingProjectInterests, address, city, state, zipCode, twitter, linkedIn, website, methodCommunication, email, phone, categoryTier, dateJoined, reasonJoining, featureImage, logoImage, follow, favoritesCount, isOwner, owner);
 	}
-	
+
 	@Override
 	public String toString()  {
 		StringBuilder sb = new StringBuilder();
 		sb.append("class Company {\n");
-		
+
 		sb.append("  id: ").append(id).append("\n");
 		sb.append("  accountId: ").append(accountId).append("\n");
 		sb.append("  name: ").append(name).append("\n");
@@ -546,7 +550,7 @@ public class Company {
 /*
     //company Builder
     public static class CompanyBuilder {
-    	
+
         private final int id;
         private final int accountId;
         private final String name;
@@ -583,178 +587,178 @@ public class Company {
         private int favoratesCount;
         private boolean isOwner;
         private String owner;
-   
+
     	public CompanyBuilder(int id, int accountId, String name) {
     		this.id = id;
     		this.accountId = accountId;
     		this.name = name;
     	}
-        
+
         public CompanyBuilder location(String location) {
         	this.location = location;
         	return this;
         }
-        
+
         public CompanyBuilder description(String description) {
         	this.description = description;
         	return this;
         }
-        
+
         public CompanyBuilder division(String division) {
         	this.division = division;
         	return this;
         }
-        
+
         public CompanyBuilder industry(String industry) {
         	this.industry = industry;
         	return this;
         }
-        
+
         public CompanyBuilder NAICSCode(String NAICSCode) {
         	this.NAICSCode = NAICSCode;
         	return this;
         }
-        
+
         public CompanyBuilder RDFocus(String RDFocus) {
         	this.RDFocus = RDFocus;
         	return this;
         }
-        
+
         public CompanyBuilder customers(String customers) {
         	this.customers = customers;
             return this;
         }
-        
+
         public CompanyBuilder awardsReceived(String awardsReceived) {
         	this.awardsReceived = awardsReceived;
         	return this;
         }
-        
+
         public CompanyBuilder technicalExpertise(String technicalExpertise) {
         	this.technicalExpertise = technicalExpertise;
         	return this;
         }
-        
+
         public CompanyBuilder toolsSoftwareEquipmentMachines(String toolsSoftwareEquipmentMachines) {
         	this.toolsSoftwareEquipmentMachines = toolsSoftwareEquipmentMachines;
         	return this;
         }
-        
+
         public CompanyBuilder postCollaborations(String postCollaborations) {
         	this.postCollaborations = postCollaborations;
         	return this;
         }
-        
+
         public CompanyBuilder collaborationInterests(String collaborationInterests) {
         	this.collaborationInterests = collaborationInterests;
         	return this;
         }
-        
+
         public CompanyBuilder pastProjects(String pastProjects) {
         	this.pastProjects = pastProjects;
         	return this;
         }
-        
+
         public CompanyBuilder upcomingProjectInterests(String upcomingProjectInterests) {
         	this.upcomingProjectInterests = upcomingProjectInterests;
         	return this;
         }
-        
+
         public CompanyBuilder address(String address) {
         	this.address = address;
         	return this;
         }
-        
+
         public CompanyBuilder city(String city) {
         	this.city = city;
         	return this;
         }
-        
+
         public CompanyBuilder state(String state) {
         	this.state = state;
         	return this;
         }
-        
+
         public CompanyBuilder zipCode(String zipCode) {
         	this.zipCode = zipCode;
         	return this;
         }
-        
+
         public CompanyBuilder twitter(String twitter) {
         	this.twitter = twitter;
         	return this;
         }
-        
+
         public CompanyBuilder linkedIn(String linkedIn) {
         	this.linkedIn = linkedIn;
         	return this;
         }
-        
+
         public CompanyBuilder website(String website) {
         	this.website = website;
         	return this;
         }
-        
+
         public CompanyBuilder methodCommunication(String methodCommunication) {
         	this.methodCommunication = methodCommunication;
         	return this;
         }
-        
+
         public CompanyBuilder email(String email) {
         	this.email = email;
         	return this;
         }
-        
+
         public CompanyBuilder phone(String phone) {
         	this.phone = phone;
         	return this;
         }
-        
+
         public CompanyBuilder categoryTier(int categoryTier) {
         	this.categoryTier = categoryTier;
         	return this;
         }
-        
+
         public CompanyBuilder dateJoined(String dateJoined) {
         	this.dateJoined = dateJoined;
         	return this;
         }
-        
+
         public CompanyBuilder reasonJoining(String reasonJoining) {
         	this.reasonJoining = reasonJoining;
         	return this;
         }
-        
+
         public CompanyBuilder featureImage(FeatureImage featureImage) {
         	this.featureImage = featureImage;
         	return this;
         }
-        
+
         public CompanyBuilder logoImage(String logoImage) {
         	this.logoImage = logoImage;
         	return this;
         }
-        
+
         public CompanyBuilder follow(boolean follow) {
         	this.follow = follow;
         	return this;
         }
-        
+
         public CompanyBuilder favoratesCount(int favoratesCount) {
         	this.favoratesCount = favoratesCount;
         	return this;
         }
-        
+
         public CompanyBuilder isOwner(boolean isOwner) {
         	this.isOwner = isOwner;
         	return this;
         }
-        
+
         public CompanyBuilder owner(String owner) {
         	this.owner = owner;
         	return this;
         }
-        
+
         public Company build() {
         	return new Company(this);
         }

--- a/src/main/java/org/dmc/services/company/CompanyController.java
+++ b/src/main/java/org/dmc/services/company/CompanyController.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 import javax.xml.ws.http.HTTPException;
 
+import com.fasterxml.jackson.annotation.JsonView;
+
 import org.dmc.services.DMCServiceException;
 import org.dmc.services.ErrorMessage;
 import org.dmc.services.Id;
@@ -18,6 +20,7 @@ import org.dmc.services.reviews.ReviewType;
 import org.dmc.services.services.Service;
 import org.dmc.services.services.ServiceDao;
 import org.dmc.services.users.User;
+import org.dmc.services.utils.RestViews;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -43,7 +46,28 @@ public class CompanyController {
      **/
     @RequestMapping(value = "/companies", method = RequestMethod.GET, produces = {APPLICATION_JSON_VALUE})
     public ResponseEntity getCompanies(@RequestHeader(value="AJP_eppn", defaultValue="testUser") String userEPPN) {
-        ServiceLogger.log(logTag, "getCompanys, userEPPN: " + userEPPN);
+        ServiceLogger.log(logTag, "getCompanies, userEPPN: " + userEPPN);
+        int statusCode = HttpStatus.OK.value();
+        ArrayList<Company> companies = null;
+
+        try {
+            companies = companyDao.getCompanies(userEPPN);
+            return new ResponseEntity<ArrayList<Company>>(companies, HttpStatus.valueOf(statusCode));
+        } catch (HTTPException e) {
+            ServiceLogger.log(logTag, e.getMessage());
+            statusCode = e.getStatusCode();
+            ErrorMessage error = new ErrorMessage.ErrorMessageBuilder(e.getMessage()).build();
+            return new ResponseEntity<ErrorMessage>(error, HttpStatus.valueOf(statusCode));
+        }
+    }
+
+    /**
+     Return a list of companies (only id, accountId, & name)
+     **/
+    @JsonView(RestViews.CompaniesShortView.class)
+    @RequestMapping(value = "/companies/short", method = RequestMethod.GET, produces = {APPLICATION_JSON_VALUE})
+    public ResponseEntity getCompaniesShort(@RequestHeader(value="AJP_eppn", defaultValue="testUser") String userEPPN) {
+        ServiceLogger.log(logTag, "getCompaniesShort, userEPPN: " + userEPPN);
         int statusCode = HttpStatus.OK.value();
         ArrayList<Company> companies = null;
 

--- a/src/main/java/org/dmc/services/data/entities/DomeServer.java
+++ b/src/main/java/org/dmc/services/data/entities/DomeServer.java
@@ -28,7 +28,7 @@ public class DomeServer extends BaseEntity {
 	private Integer id;
 	
 	@Column(name="url")
-	@JsonProperty("ip")
+	@JsonIgnore
 	private String serverURL;
 	
 	@Column(name="alias")

--- a/src/main/java/org/dmc/services/data/entities/DomeServer.java
+++ b/src/main/java/org/dmc/services/data/entities/DomeServer.java
@@ -2,6 +2,7 @@ package org.dmc.services.data.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,6 +19,8 @@ import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+import org.dmc.services.utils.RestViews;
+
 @Entity
 @Table(name="servers")
 public class DomeServer extends BaseEntity {
@@ -25,19 +28,23 @@ public class DomeServer extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name="server_id")
+	@JsonView(RestViews.SecureServerView.class)
 	private Integer id;
 	
 	@Column(name="url")
-	@JsonIgnore
+	@JsonProperty("ip")
 	private String serverURL;
 	
 	@Column(name="alias")
+	@JsonView(RestViews.SecureServerView.class)
 	private String name;
 	
 	@Column(name="user_id")
 	@JsonProperty("accountId")
+	@JsonView(RestViews.SecureServerView.class)
 	private Integer userId;
 	
+	@JsonView(RestViews.SecureServerView.class)
 	private Integer port;
 	
 	@Column(name="local_dome_user")
@@ -52,6 +59,7 @@ public class DomeServer extends BaseEntity {
 	@JsonIgnore
 	private String userPass;
 	
+	@JsonView(RestViews.SecureServerView.class)
 	private String status;
 
 	@ManyToMany
@@ -63,6 +71,7 @@ public class DomeServer extends BaseEntity {
 	
 	//helper json property to denote pub/private status
 	@JsonProperty("public")
+	@JsonView(RestViews.SecureServerView.class)
 	private Boolean isPublic(){
 		return accessList.stream().anyMatch(g->"global".equals(g.getName()));
 	}

--- a/src/main/java/org/dmc/services/data/repositories/DomeServerRepository.java
+++ b/src/main/java/org/dmc/services/data/repositories/DomeServerRepository.java
@@ -15,5 +15,9 @@ public interface DomeServerRepository extends BaseRepository<DomeServer, Integer
 			+ " 	Left Join sal.users u" 
 			+ " where u.id = :id or s.userId = :id")
 	public Page<DomeServer> findAllServers(@Param("id") Integer id, Pageable page);
+	
+	@Query("SELECT serverURL FROM DomeServer s"
+			+ " WHERE s.id = :id")
+	public String getServerURLById(@Param("id") Integer id);
 
 }

--- a/src/main/java/org/dmc/services/services/DomeAPIController.java
+++ b/src/main/java/org/dmc/services/services/DomeAPIController.java
@@ -3,6 +3,7 @@ package org.dmc.services.services;
 import java.math.BigDecimal;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.dmc.services.ServiceLogger;
 import org.dmc.services.DMCError;
 import org.dmc.services.DMCServiceException;
+import org.dmc.services.DomeServerService;
 
 import static org.springframework.http.MediaType.*;
 
@@ -25,6 +27,9 @@ public class DomeAPIController {
 
 	private final String logTag = DomeAPIController.class.getName();
 	private DomeAPIDao domeAPIDao = new DomeAPIDao();
+	
+	@Autowired
+    DomeServerService serverService;
 
 	@RequestMapping(value = "/getChildren", produces = { "application/json" }, method = RequestMethod.GET)
 	public ResponseEntity getChildrenFromDome(
@@ -45,7 +50,7 @@ public class DomeAPIController {
 			DomeEntity domeEntity = new DomeEntity();
 			domeEntity.setDateModified(dateModified);
 			domeEntity.setDescription(description);
-			domeEntity.setDomeServer(domeServer);
+			domeEntity.setDomeServer(serverService.getServerURLById(Integer.valueOf(domeServer)));
 			domeEntity.setModelId(modelId);
 			domeEntity.setName(name);
 			domeEntity.setPath(path);

--- a/src/main/java/org/dmc/services/services/DomeAPIController.java
+++ b/src/main/java/org/dmc/services/services/DomeAPIController.java
@@ -86,7 +86,7 @@ public class DomeAPIController {
 			DomeModel domeModel = new DomeModel();
 			domeModel.setProjectId(projectId);
 			domeModel.setInterfaceId(interfaceId);
-			domeModel.setDomeServer(domeServer);
+			domeModel.setDomeServer(serverService.getServerURLById(Integer.valueOf(domeServer)));
 			domeModel.setModelId(modelId);
 			domeModel.setName(name);
 			domeModel.setPath(path);

--- a/src/main/java/org/dmc/services/utils/RestViews.java
+++ b/src/main/java/org/dmc/services/utils/RestViews.java
@@ -1,0 +1,6 @@
+package org.dmc.services.utils;
+
+public class RestViews {
+  public static class CompaniesShortView {}
+
+}

--- a/src/main/java/org/dmc/services/utils/RestViews.java
+++ b/src/main/java/org/dmc/services/utils/RestViews.java
@@ -1,6 +1,18 @@
 package org.dmc.services.utils;
 
 public class RestViews {
-  public static class CompaniesShortView {}
+	
+  /**
+ * @author emiliano
+ * View for the "short" list of info for companies
+ * Only returns "id", "accountId", and "name"
+ */
+public static class CompaniesShortView {}
+
+/**
+ * @author emiliano
+ * Returns DOME Server information without IP address
+ */
+public static class SecureServerView {}
 
 }


### PR DESCRIPTION
Additionally, getChildren now gets DOME interfaces by ID instead of IP, effectively masking the IP from the client. Also added Javadoc to document what methods are doing/returning.

DEPENDENT ON DMCFRONT PULL REQUEST TITLED "Added new endpoint /accounts/{id}/servers, changed getChildren to pass ID instead of IP"