### PR TITLE
Create company and set admin based on payment

### DIFF
--- a/src/main/java/org/dmc/services/ResourceGroupService.java
+++ b/src/main/java/org/dmc/services/ResourceGroupService.java
@@ -55,7 +55,9 @@ public class ResourceGroupService {
 
 		for(String role: roles) {
 			ResourceGroup group = resourceGroupRepository.findByParentTypeAndParentIdAndRole(parentType, parentId, role);
-			resourceGroupRepository.delete(group);
+			if(group != null) {
+				resourceGroupRepository.delete(group);
+			}
 		}
 	}
 	

--- a/src/main/java/org/dmc/services/ResourceGroupService.java
+++ b/src/main/java/org/dmc/services/ResourceGroupService.java
@@ -42,7 +42,10 @@ public class ResourceGroupService {
     	List<String> roles = Arrays.asList(SecurityRoles.ADMIN, SecurityRoles.MEMBER);
 
 		for(String role: roles) {
-			ResourceGroup group = new ResourceGroup(parentType, parentId, role);
+			ResourceGroup group = resourceGroupRepository.findByParentTypeAndParentIdAndRole(parentType, parentId, role);
+			if(group == null) {
+				group = new ResourceGroup(parentType, parentId, role);
+			}
 			resourceGroupRepository.save(group);
 		}
 	}

--- a/src/main/java/org/dmc/services/data/entities/UserRoleAssignmentRO.java
+++ b/src/main/java/org/dmc/services/data/entities/UserRoleAssignmentRO.java
@@ -1,0 +1,99 @@
+package org.dmc.services.data.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.Immutable;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Table(name = "user_role_assignment")
+@Immutable
+public class UserRoleAssignmentRO extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Integer id;
+
+	@JoinColumn(name = "user_id")
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User user;
+
+	@Column(name = "organization_id")
+	private Integer organizationId;
+	
+	@JoinColumn(name = "role_id")
+	@ManyToOne
+	private Role role;
+
+	public Integer getId() {
+		return id;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	public Integer getOrgId() {
+		return organizationId;
+	}
+
+	public Role getRole() {
+		return role;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + ((organizationId == null) ? 0 : organizationId.hashCode());
+		result = prime * result + ((role == null) ? 0 : role.hashCode());
+		result = prime * result + ((user == null) ? 0 : user.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		UserRoleAssignmentRO other = (UserRoleAssignmentRO) obj;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (organizationId == null) {
+			if (other.organizationId != null)
+				return false;
+		} else if (!organizationId.equals(other.organizationId))
+			return false;
+		if (role == null) {
+			if (other.role != null)
+				return false;
+		} else if (!role.equals(other.role))
+			return false;
+		if (user == null) {
+			if (other.user != null)
+				return false;
+		} else if (!user.equals(other.user))
+			return false;
+		return true;
+	}
+
+}

--- a/src/main/java/org/dmc/services/data/models/OrganizationModel.java
+++ b/src/main/java/org/dmc/services/data/models/OrganizationModel.java
@@ -65,7 +65,7 @@ public class OrganizationModel extends BaseModel {
 	private String otherOrganizationTags;
 	
 	@JsonIgnore
-	private Boolean isPaid;
+	private Boolean isPaid = false;
 
 	public String getName() {
 		return name;

--- a/src/main/java/org/dmc/services/data/models/OrganizationModel.java
+++ b/src/main/java/org/dmc/services/data/models/OrganizationModel.java
@@ -3,6 +3,9 @@ package org.dmc.services.data.models;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class OrganizationModel extends BaseModel {
 
 	private String name;
@@ -60,6 +63,9 @@ public class OrganizationModel extends BaseModel {
 	private String dmdiiMembershipInfo;
 	
 	private String otherOrganizationTags;
+	
+	@JsonIgnore
+	private Boolean isPaid;
 
 	public String getName() {
 		return name;
@@ -283,6 +289,16 @@ public class OrganizationModel extends BaseModel {
 
 	public void setOtherOrganizationTags(String otherOrganizationTags) {
 		this.otherOrganizationTags = otherOrganizationTags;
+	}
+	
+	@JsonProperty
+	public Boolean getIsPaid() {
+		return isPaid;
+	}
+	
+	@JsonIgnore
+	public void setIsPaid(Boolean isPaid) {
+		this.isPaid = isPaid;
 	}
 
 }

--- a/src/main/java/org/dmc/services/data/models/PaymentsStatus.java
+++ b/src/main/java/org/dmc/services/data/models/PaymentsStatus.java
@@ -1,0 +1,30 @@
+package org.dmc.services.data.models;
+
+public class PaymentsStatus {
+	
+	private String status;
+	
+	private String reason;
+	
+	public PaymentsStatus(String status, String reason) {
+		this.status = status;
+		this.reason = reason;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public String getReason() {
+		return reason;
+	}
+
+	public void setReason(String reason) {
+		this.reason = reason;
+	}
+
+}

--- a/src/main/java/org/dmc/services/data/repositories/OrganizationRepository.java
+++ b/src/main/java/org/dmc/services/data/repositories/OrganizationRepository.java
@@ -2,10 +2,15 @@ package org.dmc.services.data.repositories;
 
 import com.mysema.query.types.Predicate;
 import org.dmc.services.data.entities.Organization;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface OrganizationRepository extends BaseRepository<Organization, Integer> {
 
 	List<Organization> findAll(Predicate predicate);
+	
+	@Query(value = "SELECT * FROM organization WHERE organization_id = ?1 AND is_deleted='TRUE'", nativeQuery = true)
+	Organization findDeleted(Integer id);
 }

--- a/src/main/java/org/dmc/services/data/repositories/OrganizationRepository.java
+++ b/src/main/java/org/dmc/services/data/repositories/OrganizationRepository.java
@@ -11,6 +11,6 @@ public interface OrganizationRepository extends BaseRepository<Organization, Int
 
 	List<Organization> findAll(Predicate predicate);
 	
-	@Query(value = "SELECT * FROM organization WHERE organization_id = ?1 AND is_deleted='TRUE'", nativeQuery = true)
+	@Query(value = "SELECT * FROM organization WHERE organization_id = ?1", nativeQuery = true)
 	Organization findDeleted(Integer id);
 }

--- a/src/main/java/org/dmc/services/data/repositories/UserRoleAssignmentRepository.java
+++ b/src/main/java/org/dmc/services/data/repositories/UserRoleAssignmentRepository.java
@@ -1,9 +1,16 @@
 package org.dmc.services.data.repositories;
 
 import org.dmc.services.data.entities.UserRoleAssignment;
+import org.dmc.services.data.entities.UserRoleAssignmentRO;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRoleAssignmentRepository extends BaseRepository<UserRoleAssignment, Integer> {
 	
 	void deleteByUserIdAndOrganizationId(Integer userId, Integer organizationId);
+	
+	@Query("SELECT u FROM UserRoleAssignmentRO u WHERE "
+			+ "u.id = (SELECT MAX(uu.id) from UserRoleAssignmentRO uu WHERE user_id = :id)")
+	UserRoleAssignmentRO findByUserId(@Param ("id") Integer id);
 
 }

--- a/src/main/java/org/dmc/services/organization/OrganizationController.java
+++ b/src/main/java/org/dmc/services/organization/OrganizationController.java
@@ -1,15 +1,18 @@
 package org.dmc.services.organization;
 
+import org.dmc.services.data.models.BaseModel;
 import org.dmc.services.data.models.OrganizationModel;
 import org.dmc.services.exceptions.MissingIdException;
 import org.dmc.services.security.PermissionEvaluationHelper;
 import org.dmc.services.security.SecurityRoles;
+import org.dmc.services.security.UserPrincipal;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -51,6 +54,11 @@ public class OrganizationController {
 
 		return organizationModel;
 
+	}
+	
+	@RequestMapping(value = "/organizations/user", method = RequestMethod.GET)
+	public OrganizationModel getOrganizationByUser() {
+		return organizationService.findByUser();
 	}
 
 	@RequestMapping(value = "/organizations/myVPC", method = RequestMethod.GET)

--- a/src/main/java/org/dmc/services/organization/OrganizationService.java
+++ b/src/main/java/org/dmc/services/organization/OrganizationService.java
@@ -154,6 +154,15 @@ public class OrganizationService {
 			if(organizationEntity.getAddress().getId() == null) {
 				organizationEntity.getAddress().setId(existingOrg.getAddress().getId());
 			}
+			
+			User userEntity = userRepository.findOne(((UserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getId());
+			
+			//Update ResourceGroups for Organization
+			resourceGroupService.newCreate(DocumentParentType.ORGANIZATION, organizationEntity.getId());
+
+			//add user to admin resource group
+			resourceGroupService.addUserResourceGroup(userEntity, DocumentParentType.ORGANIZATION, organizationEntity.getId(), "ADMIN");
+			
 			organizationEntity.setLogoImage(existingOrg.getLogoImage());
 
 			RecentUpdateController recentUpdateController = new RecentUpdateController();

--- a/src/main/java/org/dmc/services/organization/OrganizationService.java
+++ b/src/main/java/org/dmc/services/organization/OrganizationService.java
@@ -30,11 +30,13 @@ import org.dmc.services.data.repositories.UserRepository;
 import org.dmc.services.data.repositories.UserRoleAssignmentRepository;
 import org.dmc.services.recentupdates.RecentUpdateController;
 import org.dmc.services.roleassignment.UserRoleAssignmentService;
+import org.dmc.services.security.PermissionEvaluationHelper;
 import org.dmc.services.security.SecurityRoles;
 import org.dmc.services.security.UserPrincipal;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
@@ -140,10 +142,15 @@ public class OrganizationService {
 			resourceGroupService.addUserResourceGroup(userEntity, DocumentParentType.ORGANIZATION, organizationEntity.getId(), "ADMIN");
 
 		} else {
+			if (!PermissionEvaluationHelper.userHasRole(SecurityRoles.ADMIN, organizationEntity.getId())) {
+				throw new AccessDeniedException("403 Access denied");
+			}
 			Organization existingOrg = organizationRepository.findOne(organizationEntity.getId());
+			
 			if(existingOrg == null) {
 				existingOrg = organizationRepository.findDeleted(organizationEntity.getId());
 			}
+			
 			organizationEntity.setLogoImage(existingOrg.getLogoImage());
 
 			RecentUpdateController recentUpdateController = new RecentUpdateController();

--- a/src/main/java/org/dmc/services/organization/OrganizationService.java
+++ b/src/main/java/org/dmc/services/organization/OrganizationService.java
@@ -140,12 +140,17 @@ public class OrganizationService {
 			resourceGroupService.addUserResourceGroup(userEntity, DocumentParentType.ORGANIZATION, organizationEntity.getId(), "ADMIN");
 
 		} else {
-			Organization existingOrg = this.organizationRepository.findOne(organizationEntity.getId());
+			Organization existingOrg = organizationRepository.findOne(organizationEntity.getId());
+			if(existingOrg == null) {
+				existingOrg = organizationRepository.findDeleted(organizationEntity.getId());
+			}
 			organizationEntity.setLogoImage(existingOrg.getLogoImage());
 
 			RecentUpdateController recentUpdateController = new RecentUpdateController();
 			recentUpdateController.addRecentUpdate(organizationEntity, existingOrg);
 
+			//Use isPaid value from existing org
+			organizationEntity.setIsPaid(existingOrg.getIsPaid());
 			organizationEntity = organizationRepository.save(organizationEntity);
 		}
 

--- a/src/main/java/org/dmc/services/organization/OrganizationService.java
+++ b/src/main/java/org/dmc/services/organization/OrganizationService.java
@@ -151,6 +151,9 @@ public class OrganizationService {
 				existingOrg = organizationRepository.findDeleted(organizationEntity.getId());
 			}
 			
+			if(organizationEntity.getAddress().getId() == null) {
+				organizationEntity.getAddress().setId(existingOrg.getAddress().getId());
+			}
 			organizationEntity.setLogoImage(existingOrg.getLogoImage());
 
 			RecentUpdateController recentUpdateController = new RecentUpdateController();

--- a/src/main/java/org/dmc/services/payments/PaymentsController.java
+++ b/src/main/java/org/dmc/services/payments/PaymentsController.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.dmc.services.data.models.OrgCreation;
 import org.dmc.services.data.models.OrganizationModel;
+import org.dmc.services.data.models.PaymentsStatus;
 import org.dmc.services.organization.OrganizationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -27,32 +28,29 @@ public class PaymentsController {
 	private OrganizationService organizationService;
 
 	@RequestMapping(value = "/payment", method = RequestMethod.POST)
-	public ResponseEntity<String> makePayment(@RequestBody OrgCreation orgCreation) {
+	public ResponseEntity<PaymentsStatus> makePayment(@RequestBody OrgCreation orgCreation) {
 
 		OrganizationModel orgModel = organizationService.save(orgCreation.getOrganizationModel());
+		Charge charge = new Charge();
+		charge.setStatus("failed");
 		
 		if (orgModel != null) {
 			String token = orgCreation.getStripeToken();
-			Map<String, Object> params = new HashMap<String, Object>();
-			params.put("amount", 50000);
-			params.put("currency", "usd");
-			params.put("description", "Example charge");
-			params.put("source", token);
 			try {
 				//Will throw an exception if payment fails
-				Charge charge = paymentsService.createCharge(params);
+				charge = paymentsService.createCharge(token);
 				//Should be true if payment was successful
 				if(charge.getPaid()) {
 					organizationService.updatePayment(orgModel, true);
 				}
-				return new ResponseEntity<String>(charge.getStatus(), HttpStatus.OK);
+				return new ResponseEntity<PaymentsStatus>(new PaymentsStatus(charge.getStatus(), "Payment Successful!"), HttpStatus.OK);
 			} catch (StripeException e) {
 				organizationService.delete(orgModel.getId());
-				return new ResponseEntity<String>(e.getMessage(), HttpStatus.OK);
+				return new ResponseEntity<PaymentsStatus>(new PaymentsStatus(charge.getStatus(), e.getMessage()), HttpStatus.OK);
 			}
 		
 		} else {
-			return new ResponseEntity<String>("Organization creation failed!", HttpStatus.INTERNAL_SERVER_ERROR);
+			return new ResponseEntity<PaymentsStatus>(new PaymentsStatus(charge.getStatus(), "Org creation failed!"), HttpStatus.OK);
 		}
 
 	}

--- a/src/main/java/org/dmc/services/payments/PaymentsController.java
+++ b/src/main/java/org/dmc/services/payments/PaymentsController.java
@@ -1,8 +1,5 @@
 package org.dmc.services.payments;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.dmc.services.data.models.OrgCreation;
 import org.dmc.services.data.models.OrganizationModel;
 import org.dmc.services.data.models.PaymentsStatus;
@@ -38,7 +35,7 @@ public class PaymentsController {
 			String token = orgCreation.getStripeToken();
 			try {
 				//Will throw an exception if payment fails
-				charge = paymentsService.createCharge(token);
+				charge = paymentsService.createCharge(token, orgModel.getName());
 				//Should be true if payment was successful
 				if(charge.getPaid()) {
 					organizationService.updatePayment(orgModel, true);

--- a/src/main/java/org/dmc/services/payments/PaymentsController.java
+++ b/src/main/java/org/dmc/services/payments/PaymentsController.java
@@ -3,28 +3,17 @@ package org.dmc.services.payments;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.dmc.services.data.models.OrgCreation;
 import org.dmc.services.data.models.OrganizationModel;
 import org.dmc.services.organization.OrganizationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestTemplate;
 
-import com.stripe.Stripe;
-import com.stripe.exception.APIConnectionException;
-import com.stripe.exception.APIException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Charge;
 
@@ -38,7 +27,7 @@ public class PaymentsController {
 	private OrganizationService organizationService;
 
 	@RequestMapping(value = "/payment", method = RequestMethod.POST)
-	public ResponseEntity<String> makePayment(@RequestBody OrgCreation orgCreation, HttpServletRequest request) {
+	public ResponseEntity<String> makePayment(@RequestBody OrgCreation orgCreation) {
 
 		OrganizationModel orgModel = organizationService.save(orgCreation.getOrganizationModel());
 		
@@ -59,7 +48,7 @@ public class PaymentsController {
 				return new ResponseEntity<String>(charge.getStatus(), HttpStatus.OK);
 			} catch (StripeException e) {
 				organizationService.delete(orgModel.getId());
-				return new ResponseEntity<String>(e.getMessage(), HttpStatus.valueOf(e.getStatusCode()));
+				return new ResponseEntity<String>(e.getMessage(), HttpStatus.OK);
 			}
 		
 		} else {

--- a/src/main/java/org/dmc/services/payments/PaymentsService.java
+++ b/src/main/java/org/dmc/services/payments/PaymentsService.java
@@ -1,10 +1,13 @@
 package org.dmc.services.payments;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.PostConstruct;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import com.stripe.Stripe;
@@ -13,6 +16,7 @@ import com.stripe.exception.APIException;
 import com.stripe.exception.AuthenticationException;
 import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.model.Charge;
 
 @Service
@@ -26,10 +30,17 @@ public class PaymentsService {
 		Stripe.apiKey = stripeSKey;
 	}
 
-	public Charge createCharge(Map<String, Object> chargeParams) throws AuthenticationException,
+	public Charge createCharge(String token) throws AuthenticationException,
 			InvalidRequestException, APIConnectionException, CardException, APIException {
 		
-		return Charge.create(chargeParams);
+		Map<String, Object> params = new HashMap<String, Object>();
+		params.put("amount", 50000);
+		params.put("currency", "usd");
+		params.put("description", "Example charge");
+		params.put("source", token);
+		//Will throw an exception if payment fails
+		return Charge.create(params);
 		
 	}
+	
 }

--- a/src/main/java/org/dmc/services/payments/PaymentsService.java
+++ b/src/main/java/org/dmc/services/payments/PaymentsService.java
@@ -6,8 +6,6 @@ import java.util.Map;
 import javax.annotation.PostConstruct;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import com.stripe.Stripe;
@@ -16,27 +14,33 @@ import com.stripe.exception.APIException;
 import com.stripe.exception.AuthenticationException;
 import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
-import com.stripe.exception.StripeException;
 import com.stripe.model.Charge;
 
 @Service
 public class PaymentsService {
 
-	@Value("${STRIPE_SKEY}")
+	@Value("${STRIPE_SKEY:empty}")
 	private String stripeSKey;
+	
+	@Value("${STRIPE_T_SKEY}")
+	private String stripeTSKey;
 
 	@PostConstruct
 	public void init() {
-		Stripe.apiKey = stripeSKey;
+		if("empty".equals(stripeSKey)) {
+			Stripe.apiKey = stripeTSKey;
+		} else {
+			Stripe.apiKey = stripeSKey;
+		}
 	}
 
-	public Charge createCharge(String token) throws AuthenticationException,
+	public Charge createCharge(String token, String name) throws AuthenticationException,
 			InvalidRequestException, APIConnectionException, CardException, APIException {
 		
 		Map<String, Object> params = new HashMap<String, Object>();
 		params.put("amount", 50000);
 		params.put("currency", "usd");
-		params.put("description", "Example charge");
+		params.put("description", "Example charge for " + name);
 		params.put("source", token);
 		//Will throw an exception if payment fails
 		return Charge.create(params);


### PR DESCRIPTION
Org/Company should now have a flag in DB is_paid that will turn "TRUE" on successful payment with Stripe API. A new endpoint /organization/user will retrieve the organization for a user who is the admin of one to help reduce duplicate organizations and fill in the registration form for a returning user.

*** Dependent on dmcfront PR named: "Yb new onboarding" ***
*** Dependent on dmcdb PR named: "Adding columns for dmdii membership and payment" ***